### PR TITLE
Properly handle content-type header

### DIFF
--- a/camino.js
+++ b/camino.js
@@ -82,7 +82,16 @@ if( typeof module !== "undefined" && module.exports ) {
 				busboy.on( 'finish', function() {
 					// parse for nested/multidemensional form fields
 					// getting rid of this parsing shit soon
-					req.data = qs.parse( req.data );
+					
+					var type = /[^;?]*/.exec(req.headers['content-type'])[0];
+					
+					if(type == 'application/json') {
+						req.data = JSON.parse( req.data );
+					}
+					else {
+						req.data = qs.parse( req.data );
+					}
+					
 					req.files = qs.parse( req.files );
 
 					// fire off route callback
@@ -106,7 +115,14 @@ if( typeof module !== "undefined" && module.exports ) {
 
 				req.on( 'end', function() {
 					// parse the query string
-					req.data = qs.parse( req.data );
+					var type = /[^;?]*/.exec(req.headers['content-type'])[0];
+					
+					if(type == 'application/json') {
+						req.data = JSON.parse( req.data );
+					}
+					else {
+						req.data = qs.parse( req.data );
+					}
 
 					// fire off the callback
 					self.exec( req );

--- a/camino.js
+++ b/camino.js
@@ -45,9 +45,10 @@ if( typeof module !== "undefined" && module.exports ) {
 
 
 			var type = req.headers["content-type"] || '';
+			type = /[^;?]*/.exec(type.toLowerCase())[0];
 
 			// process multipart form data (uploads...)
-			if( type.indexOf( 'multipart/form-data' ) !== -1 ) {
+			if( type == 'multipart/form-data' ) {
 				// don't combine these two, bad things will happen
 				req.files = {};
 				req.data = {};
@@ -82,16 +83,7 @@ if( typeof module !== "undefined" && module.exports ) {
 				busboy.on( 'finish', function() {
 					// parse for nested/multidemensional form fields
 					// getting rid of this parsing shit soon
-					
-					var type = /[^;?]*/.exec(req.headers['content-type'])[0];
-					
-					if(type == 'application/json') {
-						req.data = JSON.parse( req.data );
-					}
-					else {
-						req.data = qs.parse( req.data );
-					}
-					
+					req.data = qs.parse( req.data );
 					req.files = qs.parse( req.files );
 
 					// fire off route callback
@@ -114,13 +106,11 @@ if( typeof module !== "undefined" && module.exports ) {
 				});
 
 				req.on( 'end', function() {
-					// parse the query string
-					var type = /[^;?]*/.exec(req.headers['content-type'])[0];
-					
 					if(type == 'application/json') {
 						req.data = JSON.parse( req.data );
 					}
 					else {
+						// parse the query string
 						req.data = qs.parse( req.data );
 					}
 


### PR DESCRIPTION
If content-type is specified as application/json, treat request data as JSON rather than a query string.
